### PR TITLE
Create local dev and production config values file

### DIFF
--- a/src/main/resources/application-localdev.properties
+++ b/src/main/resources/application-localdev.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:mysql://localhost/viewdb?serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.devtools.restart.poll-interval=500


### PR DESCRIPTION
NOTE: the command to run the application in local dev has changed:

    mvn spring-boot:run -Dspring-boot.run.profiles=localdev

This new springboot command should be run locally and instructs springboot to select the local database configuration file `application-localdev.properties`.

Hopefully, this change is compatible with the tip of master.